### PR TITLE
Remove auto-approval for reconnecting peers

### DIFF
--- a/app/src/hooks/usePasswordProtection.ts
+++ b/app/src/hooks/usePasswordProtection.ts
@@ -30,19 +30,6 @@ export function usePasswordProtection({
 
     // Wait a bit to ensure participant's listener is ready
     setTimeout(() => {
-      // Check if this peer was already approved (same peer reconnecting)
-      if (approvedParticipants.current.has(peerId)) {
-        console.log('[PasswordProtection] Peer already approved, auto-approving:', peerId);
-
-        const approvalMessage: PasswordMessage = {
-          type: 'PASSWORD_APPROVED',
-          payload: {}
-        };
-        peerService.sendDataMessage(peerId, approvalMessage);
-        onParticipantApproved?.(peerId);
-        return;
-      }
-
       // Check if max participants limit is exceeded
       if (currentParticipantCount >= PARTICIPANT_CONFIG.MAX_PARTICIPANTS) {
         console.log('[PasswordProtection] Max participants exceeded. Current:', currentParticipantCount, 'Max:', PARTICIPANT_CONFIG.MAX_PARTICIPANTS);


### PR DESCRIPTION
Eliminated logic that automatically approves peers who reconnect if they were previously approved. This change ensures all participants go through the password protection flow, even on reconnection.