### PR TITLE
Add focus handlers to PasswordInput component

### DIFF
--- a/app/src/components/shared/PasswordInput.tsx
+++ b/app/src/components/shared/PasswordInput.tsx
@@ -11,6 +11,8 @@ interface PasswordInputProps {
   placeholder?: string;
   disabled?: boolean;
   error?: boolean;
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 export function PasswordInput({
@@ -19,7 +21,9 @@ export function PasswordInput({
   onSubmit,
   placeholder = 'Enter password',
   disabled = false,
-  error = false
+  error = false,
+  onFocus,
+  onBlur
 }: PasswordInputProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [lengthError, setLengthError] = useState<string | null>(null);
@@ -58,6 +62,8 @@ export function PasswordInput({
         value={value}
         onChange={(e) => handleChange(e.target.value)}
         onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        onBlur={onBlur}
         disabled={disabled}
         maxLength={PASSWORD_CONFIG.MAX_LENGTH}
       />

--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -634,6 +634,8 @@ export function LandingPage() {
                                         onChange={setHostPassword}
                                         placeholder={JOIN_FLOW.ROOM_PASSWORD_OPTIONAL}
                                         disabled={false}
+                                        onFocus={() => setIsInputFocused(true)}
+                                        onBlur={() => setIsInputFocused(false)}
                                     />
                                 </div>
                                 <button className="menu-button menu-button--secondary" onClick={handleBack} key="settings-back" data-delay="0">
@@ -687,6 +689,8 @@ export function LandingPage() {
                                                 placeholder={JOIN_FLOW.PASSWORD_REQUIRED}
                                                 disabled={isVerifying}
                                                 error={!!passwordError}
+                                                onFocus={() => setIsInputFocused(true)}
+                                                onBlur={() => setIsInputFocused(false)}
                                             />
                                         </div>
                                         <button


### PR DESCRIPTION
## Description
On the landing page, mobile and tablet devices should not display env(safe-area-inset-bottom) when the virtual keyboard is visible. Previously, this behavior was applied only to the Session ID input, while the password input was not handled correctly. This issue has now been fixed.


## Type of Change
- [x] Bug fix (bugs/)
- [ ] New feature (features/)
- [ ] Refactoring (refactor/)
- [ ] Hotfix (hotfix/)


## Changes Made
- Applied consistent handling of env(safe-area-inset-bottom) when the virtual keyboard is visible on mobile and tablet devices
- Extended the existing behavior from the Session ID input to the password input on the landing page


## Checklist
- [x] Code follows the project's coding style
- [x] Self-review completed