### PR TITLE
Enhance video degradation preference handling

### DIFF
--- a/app/src/pages/HostPage.tsx
+++ b/app/src/pages/HostPage.tsx
@@ -45,7 +45,8 @@ export function HostPage() {
 
   const { disconnect, getShareLink, participantCount } = usePeerConnection({
     role: 'host',
-    stream
+    stream,
+    sourceType
   });
 
   useEffect(() => {

--- a/app/src/services/mediaService.ts
+++ b/app/src/services/mediaService.ts
@@ -2,6 +2,14 @@ import { CAMERA_CONSTRAINTS, SCREEN_CONSTRAINTS, ERROR_MESSAGES } from '../confi
 import type { MediaSourceType } from '../types/media.types';
 
 export type CameraFacingMode = 'user' | 'environment';
+type VideoContentHint = 'detail' | 'motion' | 'text' | 'none';
+
+const applyVideoContentHint = (track: MediaStreamTrack | undefined, hint: VideoContentHint) => {
+  if (!track) return;
+  if ('contentHint' in track) {
+    track.contentHint = hint;
+  }
+};
 
 class MediaService {
   private currentStream: MediaStream | null = null;
@@ -59,6 +67,7 @@ class MediaService {
         }
       };
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      applyVideoContentHint(stream.getVideoTracks()[0], 'motion');
       this.currentStream = stream;
       this.currentFacingMode = targetFacingMode;
       return stream;
@@ -70,6 +79,7 @@ class MediaService {
   async getScreenStream(): Promise<MediaStream> {
     try {
       const stream = await navigator.mediaDevices.getDisplayMedia(SCREEN_CONSTRAINTS);
+      applyVideoContentHint(stream.getVideoTracks()[0], 'detail');
       this.currentStream = stream;
 
       stream.getVideoTracks()[0].addEventListener('ended', () => {


### PR DESCRIPTION
## Description
- Introduced degradation preference handling in usePeerConnection for adaptive video quality based on media source type.
- Added video content hint application in media streams for better streaming quality, distinguishing between camera and screen streaming.
- Implemented applyVideoDegradationPreference for peer connections in peerService to adjust preferences during calls.


## Type of Change
- [ ] Bug fix (bugs/)
- [x] New feature (features/)
- [ ] Refactoring (refactor/)
- [ ] Hotfix (hotfix/)


## Changes Made
- Applied `contentHint` on video tracks based on source type (camera vs screen).
- Added degradation preference support in `peerService.callPeer` and helper.
- Wired source type into `usePeerConnection` to set/update degradation preference for calls.


## Checklist
- [x] Code follows the project's coding style
- [x] Self-review completed