### PR TITLE
Fix participant stream sizing to preserve aspect ratio on Share page

### DIFF
--- a/app/styles/components/participant.scss
+++ b/app/styles/components/participant.scss
@@ -30,12 +30,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 
   &__video {
-    max-width: 100%;
-    max-height: 100%;
-    width: auto;
-    height: auto;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
     background-color: var(--bg-video);
   }


### PR DESCRIPTION
## Description
Fixes the Share (participant) page where the video appeared zoomed and stretched. The stream now fits the container while preserving aspect ratio, aligning with the host page behavior.

## Type of Change
- [x] Bug fix (bugs/)
- [ ] New feature (features/)
- [ ] Refactoring (refactor/)
- [ ] Hotfix (hotfix/)
- [ ] Chore (chore/)

## Changes Made
- Align participant video sizing to the container
- Add overflow clipping to prevent zoomed spill
- Keep object-fit: contain for aspect ratio preservation

## Checklist
- [x] Code follows the project's coding style
- [x] Self-review completed
- [x] Documentation updated (if necessary)