### PR TITLE
Fix share leave navigation for hash router deployments

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perspective",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perspective",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "jsqr": "^1.4.0",
         "peerjs": "^1.5.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perspective",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src/pages/ParticipantPage.tsx
+++ b/app/src/pages/ParticipantPage.tsx
@@ -70,7 +70,7 @@ export function ParticipantPage() {
     setParticipantPeer(cleanupParticipantPeer(participantPeer));
     setRemoteStream(null);
     setConnectionStatus('idle');
-    window.location.href = '/';
+    navigate('/', { replace: true });
   };
 
   // Clean up on unmount


### PR DESCRIPTION
## Description
Fix the leave action on the Share page so it uses hash-router navigation instead of `window.location.href`. This prevents redirects to the web root and correctly returns to the landing page on GitHub Pages deployments.

## Type of Change
- [ ] Bug fix (bugs/)
- [ ] New feature (features/)
- [ ] Refactoring (refactor/)
- [x] Hotfix (hotfix/)
- [ ] Chore (chore/)

## Changes Made
- Switched Share page leave navigation to hash-router `navigate('/')`

## Checklist
- [x] Code follows the project's coding style
- [x] Self-review completed