### PR TITLE
Improve Peer initialization with config constants

### DIFF
--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -27,7 +27,7 @@ import { useStreamContext } from '../contexts/StreamContext';
 import { PasswordInput } from '../components/shared/PasswordInput';
 import { usePasswordVerification } from '../hooks/usePasswordVerification';
 import { validateQRCodeURL, getQRErrorMessage } from '../utils/urlValidator';
-import { ERROR_MESSAGES } from '../config/constants';
+import { ERROR_MESSAGES, PEER_CONFIG, PEER_SERVER_CONFIG } from '../config/constants';
 import { hashPassword } from '../utils/passwordHasher';
 import type { DataConnection } from 'peerjs';
 import type Peer from 'peerjs';
@@ -487,7 +487,14 @@ export function LandingPage() {
             hostPeerIdForVerificationRef.current = peerIdToJoin;
 
             // Create a temporary peer to establish data connection
-            const tempPeer = new (await import('peerjs')).default();
+            const { default: Peer } = await import('peerjs');
+            const tempPeer = new Peer({
+                ...PEER_SERVER_CONFIG,
+                config: {
+                    iceServers: PEER_CONFIG.iceServers
+                },
+                debug: PEER_CONFIG.debug
+            });
             tempPeerForVerificationRef.current = tempPeer;
 
             tempPeer.on('open', () => {


### PR DESCRIPTION
## Description
This PR fixes the join verification flow so the temporary PeerJS instance respects the environment-configured PeerJS server. Previously, the temp peer defaulted to the public PeerJS server, which could break connections when the host uses a custom signaling server. The change aligns temp peer initialization with the app’s configured ICE and server settings while preserving default behavior when no custom host is provided.

## Type of Change
- [x] Bug fix (bugs/)
- [ ] New feature (features/)
- [ ] Refactoring (refactor/)
- [ ] Hotfix (hotfix/)
- [ ] Chore (chore/)

## Changes Made
- Use `PEER_SERVER_CONFIG` and `PEER_CONFIG` when creating the temporary peer in the join flow.
- Keep default PeerJS server usage when no custom host is defined.
- Align temp peer setup with the rest of the app’s PeerJS configuration for consistent signaling.

## Checklist
- [x] Code follows the project's coding style
- [x] Self-review completed