### PR TITLE
Handle stream end events to stop sharing automatically

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,6 +217,6 @@ flowchart TD
     I --> J["ConnectionStatus: idle"]
     J --> K[Redirect to LandingPage]
 
-    B -->|Screen share ended| L[Video track ended event]
+    B -->|Screen or camera share ended| L[Video track ended event]
     L --> D
 ```

--- a/app/src/hooks/useMediaStream.ts
+++ b/app/src/hooks/useMediaStream.ts
@@ -5,10 +5,14 @@ import type { MediaSourceType } from '../types/media.types';
 
 interface UseMediaStreamOptions {
   cleanupOnUnmount?: boolean;
+  onStreamEnded?: () => void;
 }
 
 export function useMediaStream(options: UseMediaStreamOptions = { cleanupOnUnmount: true }) {
+  const { cleanupOnUnmount = true, onStreamEnded } = options;
   const { streamState, setStream, setPaused, setMuted, setError, clearStream } = useStreamContext();
+  const isStoppingRef = useRef(false);
+  const hasHandledStreamEndRef = useRef(false);
 
   const startCapture = useCallback(async (sourceType: MediaSourceType) => {
     try {
@@ -32,6 +36,7 @@ export function useMediaStream(options: UseMediaStreamOptions = { cleanupOnUnmou
 
   const stopCapture = useCallback(() => {
     if (streamState.stream) {
+      isStoppingRef.current = true;
       mediaService.stopStream(streamState.stream);
       clearStream();
     }
@@ -97,12 +102,58 @@ export function useMediaStream(options: UseMediaStreamOptions = { cleanupOnUnmou
   }, [streamState.stream]);
 
   useEffect(() => {
+    isStoppingRef.current = false;
+    hasHandledStreamEndRef.current = false;
+  }, [streamState.stream]);
+
+  useEffect(() => {
+    const stream = streamState.stream;
+    if (!stream) return;
+
+    const handleTrackEnded = () => {
+      if (isStoppingRef.current || hasHandledStreamEndRef.current) return;
+      hasHandledStreamEndRef.current = true;
+      stopCapture();
+      onStreamEnded?.();
+    };
+
+    const addEndedListener = (track: MediaStreamTrack) => {
+      if (track.kind !== 'video') return;
+      track.addEventListener('ended', handleTrackEnded);
+    };
+
+    const removeEndedListener = (track: MediaStreamTrack) => {
+      if (track.kind !== 'video') return;
+      track.removeEventListener('ended', handleTrackEnded);
+    };
+
+    stream.getVideoTracks().forEach(addEndedListener);
+
+    const handleAddTrack = (event: MediaStreamTrackEvent) => {
+      addEndedListener(event.track);
+    };
+
+    const handleRemoveTrack = (event: MediaStreamTrackEvent) => {
+      removeEndedListener(event.track);
+    };
+
+    stream.addEventListener('addtrack', handleAddTrack);
+    stream.addEventListener('removetrack', handleRemoveTrack);
+
     return () => {
-      if (options.cleanupOnUnmount && streamRef.current) {
+      stream.getVideoTracks().forEach(removeEndedListener);
+      stream.removeEventListener('addtrack', handleAddTrack);
+      stream.removeEventListener('removetrack', handleRemoveTrack);
+    };
+  }, [streamState.stream, stopCapture, onStreamEnded]);
+
+  useEffect(() => {
+    return () => {
+      if (cleanupOnUnmount && streamRef.current) {
         mediaService.stopStream(streamRef.current);
       }
     };
-  }, [options.cleanupOnUnmount]); // Removed streamState.stream dependency to avoid re-triggering, relying on ref/closure or just simple unmount check if possible. But standard pattern is ok.
+  }, [cleanupOnUnmount]); // Removed streamState.stream dependency to avoid re-triggering, relying on ref/closure or just simple unmount check if possible. But standard pattern is ok.
 
 
   return {

--- a/app/src/pages/HostPage.tsx
+++ b/app/src/pages/HostPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { LocalPreview } from '../components/host/LocalPreview';
 import { HostControls } from '../components/host/HostControls';
@@ -16,6 +16,13 @@ export function HostPage() {
   const [isWaitingForStream, setIsWaitingForStream] = useState(false);
   const hasNavigatedRef = useRef(false);
   const controlsOverlayRef = useRef<HTMLDivElement>(null);
+  const disconnectRef = useRef<() => void>();
+  const handleStreamEnded = useCallback(() => {
+    if (hasNavigatedRef.current) return;
+    hasNavigatedRef.current = true;
+    disconnectRef.current?.();
+    navigate('/');
+  }, [navigate]);
   const { isOverlayVisible, handlePointerDown } = useControlsOverlay(controlsOverlayRef);
 
   const {
@@ -29,11 +36,10 @@ export function HostPage() {
     toggleVideo,
     toggleAudio,
     switchCamera
-  } = useMediaStream();
+  } = useMediaStream({ onStreamEnded: handleStreamEnded });
 
   // Store latest functions in refs for cleanup
   const stopCaptureRef = useRef(stopCapture);
-  const disconnectRef = useRef<() => void>();
 
   useEffect(() => {
     stopCaptureRef.current = stopCapture;

--- a/app/src/services/mediaService.ts
+++ b/app/src/services/mediaService.ts
@@ -95,10 +95,6 @@ class MediaService {
       applyVideoContentHint(stream.getVideoTracks()[0], 'detail');
       this.currentStream = stream;
 
-      stream.getVideoTracks()[0].addEventListener('ended', () => {
-        this.stopStream();
-      });
-
       return stream;
     } catch (error) {
       throw this.handleMediaError(error);


### PR DESCRIPTION
## Description
This PR adds explicit detection for screen/camera stream termination so the host session shuts down cleanly when sharing ends from the browser UI. The logic moves track-ended handling into the media hook, ensures the peer connection is closed, and updates the architecture documentation to reflect the behavior.

## Type of Change
- [ ] Bug fix (bugs/)
- [x] New feature (features/)
- [ ] Refactoring (refactor/)
- [ ] Hotfix (hotfix/)
- [ ] Chore (chore/)

## Changes Made
- Detect video track `ended` events in `useMediaStream` and trigger cleanup.
- End host session and disconnect peers when the stream ends unexpectedly.
- Remove duplicate end handling in `mediaService` and update `ARCHITECTURE.md`.

## Checklist
- [x] Code follows the project's coding style
- [x] Self-review completed
- [x] Documentation updated (if necessary)